### PR TITLE
Name changed status message now mentions your previous nickname.

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,9 +79,10 @@ async function work(user, msg, textAfterNumber) {
       try {
         await namesdb.run('DELETE FROM names WHERE GuildID = ? AND UserID = ?', [msg.guildId, user.id])
         await namesdb.run('INSERT INTO names (GuildID, UserID, Nickname) VALUES (?,?,?)', [msg.guildId, user.id, textAfterNumber])
+        let oldName = user.nickname;
         await user.setNickname(textAfterNumber, "Funny");
         
-        msg.reply("<@" + user.id + "> your nickname has been set :)");
+        msg.reply("<@" + user.id + "> your nickname has been changed from " + oldName + " :)");
       }
       catch (e) {
         try {


### PR DESCRIPTION
This is so you can more easily see someone's name history when reading the bot output:

@<new_name> your nickname has been changed from <old_name> :)